### PR TITLE
Add option to specify client tls cert/key.

### DIFF
--- a/jobs/docker_cpi/templates/cpi.json.erb
+++ b/jobs/docker_cpi/templates/cpi.json.erb
@@ -5,6 +5,8 @@ JSON.dump(
     "Docker" => {
       "Host"       => p("docker_cpi.docker.host"),
       "CACert"     => p("docker_cpi.docker.tls.ca"),
+      "CertFile"     => p("docker_cpi.docker.tls.certificate", ""),
+      "KeyFile"     => p("docker_cpi.docker.tls.private_key", ""),
       "APIVersion" => p("docker_cpi.docker.api_version"),
     },
 

--- a/src/github.com/cppforlife/bosh-docker-cpi/cpi/factory.go
+++ b/src/github.com/cppforlife/bosh-docker-cpi/cpi/factory.go
@@ -14,6 +14,8 @@ import (
 	bdisk "github.com/cppforlife/bosh-docker-cpi/disk"
 	bstem "github.com/cppforlife/bosh-docker-cpi/stemcell"
 	bvm "github.com/cppforlife/bosh-docker-cpi/vm"
+	"crypto/tls"
+	"fmt"
 )
 
 type Factory struct {
@@ -105,6 +107,14 @@ func (f Factory) httpClient() (*http.Client, error) {
 	tlsConfig := dkrtlsconfig.ClientDefault()
 	tlsConfig.InsecureSkipVerify = false
 	tlsConfig.RootCAs = certPool
+
+	if f.opts.Docker.CertFile != "" || f.opts.Docker.KeyFile != "" {
+		tlsCert, err := tls.X509KeyPair([]byte(f.opts.Docker.CertFile), []byte(f.opts.Docker.KeyFile))
+		if err != nil {
+			return nil, fmt.Errorf("Could not load X509 key pair: %v. Make sure the key is not encrypted", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	}
 
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/src/github.com/cppforlife/bosh-docker-cpi/cpi/factory_opts.go
+++ b/src/github.com/cppforlife/bosh-docker-cpi/cpi/factory_opts.go
@@ -14,6 +14,8 @@ type DockerOpts struct {
 	Host       string
 	CACert     string
 	APIVersion string
+	CertFile   string
+	KeyFile    string
 }
 
 func (o FactoryOpts) Validate() error {


### PR DESCRIPTION
docker-machine creates a docker daemon with tls client verification enabled. This PR allows setting the client cert/key which should make working with docker-machine smoother.