### PR TITLE
Fix multi cpi

### DIFF
--- a/src/github.com/cppforlife/bosh-docker-cpi/cpi/factory.go
+++ b/src/github.com/cppforlife/bosh-docker-cpi/cpi/factory.go
@@ -96,12 +96,14 @@ func (f Factory) New(ctx apiv1.CallContext) (apiv1.CPI, error) {
 }
 
 func (Factory) dockerOpts(ctx apiv1.CallContext, defaults DockerOpts) (DockerOpts, error) {
-	var opts DockerOpts
+	var factOpts FactoryOpts
 
-	err := ctx.As(&opts)
+	err := ctx.As(&factOpts)
 	if err != nil {
 		return DockerOpts{}, bosherr.WrapError(err, "Parsing CPI context")
 	}
+
+	opts := factOpts.Docker
 
 	if len(opts.Host) > 0 {
 		err := opts.Validate()


### PR DESCRIPTION
Without this fix the connection details for the cpi are not picked up and the settings from /var/vcap/jobs/docker_cpi/config/cpi.json are used instead.